### PR TITLE
add evmMessageToCharString, fix revert prefix and subsequent message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -808,10 +808,10 @@ class NearProvider {
             // TODO: add more logic here for various types of errors.
             const errorObj = JSON.parse(error.message.slice(error.message.indexOf('\n') + 1));
             if (errorObj.error.includes('wasm execution failed with error:')) {
-                const REVERT_PREFIX = 'FunctionCallError(EvmError(Revert("';
+                const REVERT_PREFIX = 'FunctionCallError(EvmError(Revert(';
                 if (errorObj.error.includes(REVERT_PREFIX)) {
-                    const message = errorObj.error.slice(errorObj.error.indexOf(REVERT_PREFIX) + REVERT_PREFIX.length, errorObj.error.length - 4);
-                    throw new Error('revert' + (message ? (' ' + utils.hexToString(message)) : ''));
+                    const message = errorObj.error.slice(errorObj.error.indexOf(REVERT_PREFIX) + REVERT_PREFIX.length, errorObj.error.length - 3);
+                    throw new Error('revert' + (message ? (' ' + utils.evmMessageToCharString(message)) : ''));
                 }
             }
             throw error;

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,6 +240,16 @@ utils.hexToBN = function(hex) {
 };
 
 /**
+ * Converts raw message from EVM into character codes
+ * @param {String}  value string from EVM typically of the form '[8, 19, 0, 68…]'
+ * @returns {String} returns string
+ * Note: some characters may not be utf8 compatible
+ */
+utils.evmMessageToCharString = function(msg) {
+    return JSON.parse(msg).map(i => String.fromCharCode(i)).join('');
+};
+
+/**
  * Convert timestamp in NEAR to hex
  * @param {Number} value NEAR timestamp
  * @returns {String} hex string equivalent of timestamp


### PR DESCRIPTION
now the message can be parsed for the "reason" as expected in Balancer tests.

**Closes Issue(s):** https://github.com/near/nearcore/issues/3665

**Unit tests completed?:** Y

