### PR TITLE
in createTestAccount, don't count masterAccount in total num to create

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -345,7 +345,10 @@ let __CREATE_ACCOUNT_PROMISE;
 let __CREATE_ACCOUNT_VALIDATION_CACHE = false;
 
 async function _createTestAccount(masterAccount, numAccounts) {
-    const currentAccounts = await masterAccount.connection.signer.keyStore.getAccounts(masterAccount.connection.networkId);
+    let currentAccounts = await masterAccount.connection.signer.keyStore.getAccounts(masterAccount.connection.networkId);
+    // Remove the master account if it exists, otherwise it'll create one less than numAccounts
+    const masterAccountIndex = currentAccounts.indexOf(masterAccount.accountId);
+    if (masterAccountIndex !== -1) currentAccounts.splice(masterAccountIndex, 1);
     const numCurrentAccounts = currentAccounts.length;
     if (!__CREATE_ACCOUNT_VALIDATION_CACHE) {
         // Double check that all available accounts are valid accounts for this network.


### PR DESCRIPTION
Small issue I noticed. We create test accounts before running tests. I was seeing that I would say "create 5 test accounts" and 4 would be created. This happened when I had a single KeyStore like UnencryptedFileKeyStore.
Looks like it was finding the master account key file, then counting that in the total.
This is a simple fix to make sure that when we're creating new accounts from a master account, we don't include the master account in the total if it's there.