### PR TITLE
Add network config for defaults, add fallbacks to NearProvider constructor, remo…

### DIFF
--- a/src/network-config.js
+++ b/src/network-config.js
@@ -21,8 +21,8 @@ const getNetworkConfig = function getNetworkConfig(networkId) {
                 nodeUrl: 'https://rpc.betanet.near.org',
                 networkId: 'betanet',
                 evmAccountId: 'evm',
-                walletUrl: 'https://wallet.testnet.near.org',
-                explorerUrl: 'https://explorer.testnet.near.org',
+                walletUrl: 'https://wallet.betanet.near.org',
+                explorerUrl: 'https://explorer.betanet.near.org',
             };
         case 'local':
             return {

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -1,0 +1,42 @@
+const getNetworkConfig = function getNetworkConfig(networkId) {
+    switch (networkId) {
+        case 'mainnet':
+            return {
+                nodeUrl: 'https://rpc.mainnet.near.org',
+                networkId: 'mainnet',
+                evmAccountId: 'evm',
+                walletUrl: 'https://wallet.near.org',
+                explorerUrl: 'https://explorer.near.org',
+            };
+        case 'testnet':
+            return {
+                nodeUrl: 'https://rpc.testnet.near.org',
+                networkId: 'default',
+                evmAccountId: 'evm',
+                walletUrl: 'https://wallet.testnet.near.org',
+                explorerUrl: 'https://explorer.testnet.near.org',
+            };
+        case 'betanet':
+            return {
+                nodeUrl: 'https://rpc.betanet.near.org',
+                networkId: 'betanet',
+                evmAccountId: 'evm',
+                walletUrl: 'https://wallet.testnet.near.org',
+                explorerUrl: 'https://explorer.testnet.near.org',
+            };
+        case 'local':
+            return {
+                nodeUrl: 'http://127.0.0.1:3030',
+                networkId: 'local',
+                evmAccountId: 'evm',
+                walletUrl: 'http://127.0.0.1:4000',
+                explorerUrl: 'http://127.0.0.1:3019',
+            };
+        default:
+            throw Error(`Unconfigured environment '${networkId}'. Please see project README.`);
+    }
+}
+
+module.exports = {
+    getNetworkConfig
+}


### PR DESCRIPTION
…ve creation of test acct in constructor

As discussed here:
https://github.com/near/balancer-core/pull/1#discussion_r537674354

Instead of having projects specify the `nodeUrl` every time, we can have them give the `networkId` and `masterAccount` (via environment variable) and have the network details living in this repo.

