### PR TITLE
Utility createTestAccounts: lower initial balance to 3 Ⓝ

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -372,7 +372,7 @@ async function _createTestAccount(masterAccount, numAccounts) {
         await masterAccount.connection.signer.keyStore.setKey(masterAccount.connection.networkId, accountId, keyPair);
         await masterAccount.createAccount(
             accountId, keyPair.publicKey.toString(),
-            nearAPI.utils.format.parseNearAmount('8600'));
+            nearAPI.utils.format.parseNearAmount('3'));
         newAccountIds.push(accountId);
     }
     console.log(`Created ${numAccounts - numCurrentAccounts} test accounts.`);


### PR DESCRIPTION
Looking at the git blame, I believe this came up before we implemented precompile and found that a very large number got us farther in tests. I failed to keep note of this. Originally Illia had set the initial balance to be 1 Ⓝ but that didn't pass the Balancer tests. I bumped it to 3 Ⓝ which seems reasonable, and all tests pass.