### PR TITLE
Allow view-only provider instance

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const web3Utils = require('web3-utils');
 const BN = require('bn.js');
 const fs = require('fs');
 const nearAPI = require('near-api-js');
+const { getNetworkConfig } = require('./network-config');
 
 const utils = {};
 
@@ -501,5 +502,9 @@ utils.encodeWithdrawArgs = function(recipient, amount) {
     withdrawArgs.amount = utils.deserializeHex(amount, 32);
     return nearAPI.utils.serialize.serialize(SCHEMA, withdrawArgs);
 };
+
+utils.getNetworkConfig = function(networkId) {
+    return getNetworkConfig(networkId);
+}
 
 module.exports = utils;


### PR DESCRIPTION
When working with the Pet Shop example it became clear that we were requiring a "master account" to which you had keys. There will be instances where a dApp will want to perform view transactions instead of call. (in Ethereum called "call" instead of "send", which is slightly unfortunate. 🤷🏼 )
This PR adds `isReadOnly` as an optional parameter as well as assertions and tests.
Additionally, I've allowed the `utils.js` to export the configuration defaults to clients using this library. That's going to be useful and needed.
With this setup, I am now able to open up Pet Shop (for instance) and while not be logged in with a NEAR account, see which pets need to be adopted. As soon as I log in and am redirected back, the NearProvider becomes the default (non-read-only) and transactions can be sent as expected.