### PR TITLE
Address betanet chain ID

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -22,6 +22,7 @@ consts.ZERO_ADDRESS = `0x${'00'.repeat(20)}`;
 
 consts.NEAR_NET_VERSION = '1313161554';
 consts.NEAR_NET_VERSION_TEST = '1313161555';
+consts.NEAR_NET_VERSION_BETANET = '1313161556';
 
 
 module.exports = consts;

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ class NearProvider {
         this.evm_contract = evmAccountId || networkDefaults.evmAccountId;
         this.isReadOnly = isReadOnly || false;
         this.url = nodeUrl  || networkDefaults.nodeUrl;
-        this.version = networkId === 'local' || networkId === 'test'
-            ? consts.NEAR_NET_VERSION_TEST
-            : consts.NEAR_NET_VERSION;
+        this.version = networkDefaults.version
         this.nearProvider = new nearAPI.providers.JsonRpcProvider(this.url);
 
         this.keyStore = keyStore || utils.createLocalKeyStore(this.networkId, params.keyPath);

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -1,3 +1,5 @@
+const consts = require('./consts');
+
 const getNetworkConfig = function getNetworkConfig(networkId) {
     switch (networkId) {
         case 'mainnet':
@@ -7,6 +9,7 @@ const getNetworkConfig = function getNetworkConfig(networkId) {
                 evmAccountId: 'evm',
                 walletUrl: 'https://wallet.near.org',
                 explorerUrl: 'https://explorer.near.org',
+                version: consts.NEAR_NET_VERSION
             };
         case 'testnet':
             return {
@@ -15,6 +18,7 @@ const getNetworkConfig = function getNetworkConfig(networkId) {
                 evmAccountId: 'evm',
                 walletUrl: 'https://wallet.testnet.near.org',
                 explorerUrl: 'https://explorer.testnet.near.org',
+                version: consts.NEAR_NET_VERSION_TEST
             };
         case 'betanet':
             return {
@@ -23,6 +27,7 @@ const getNetworkConfig = function getNetworkConfig(networkId) {
                 evmAccountId: 'evm',
                 walletUrl: 'https://wallet.betanet.near.org',
                 explorerUrl: 'https://explorer.betanet.near.org',
+                version: consts.NEAR_NET_VERSION_BETANET
             };
         case 'local':
             return {
@@ -31,12 +36,14 @@ const getNetworkConfig = function getNetworkConfig(networkId) {
                 evmAccountId: 'evm',
                 walletUrl: 'http://127.0.0.1:4000',
                 explorerUrl: 'http://127.0.0.1:3019',
+                version: consts.NEAR_NET_VERSION_TEST
             };
         case 'test':
             return {
                 networkId: 'test',
                 nodeUrl: 'http://localhost:3030',
-                keyPath: '../test/keys/test.near.json'
+                keyPath: '../test/keys/test.near.json',
+                version: consts.NEAR_NET_VERSION_TEST
             };
         default:
             throw Error(`Unconfigured environment '${networkId}'. Please see project README.`);


### PR DESCRIPTION
Fairly simple PR, now that betanet has its own chain ID as shown here:
https://chainid.network

Moved some logic into the network configuration instead of during instantiation of the class.

Fixes #71 

